### PR TITLE
Add socketio Flask interface

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,61 @@
+from flask import Flask, render_template, request
+from flask_socketio import SocketIO
+import subprocess
+import os
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'secret!'
+socketio = SocketIO(app)
+
+REPO_ROOT = os.path.dirname(os.path.abspath(__file__ + '/../'))
+SCRIPT_DIRS = {
+    'cambium': os.path.join(REPO_ROOT, 'cambium'),
+    'mikrotik': os.path.join(REPO_ROOT, 'mikrotik')
+}
+
+
+def get_scripts():
+    data = {}
+    for manuf, path in SCRIPT_DIRS.items():
+        if os.path.isdir(path):
+            data[manuf] = [f for f in os.listdir(path) if f.endswith('.py')]
+    return data
+
+
+@app.route('/')
+def index():
+    scripts = get_scripts()
+    return render_template('index.html', scripts=scripts)
+
+
+@socketio.on('run_script')
+def run_script(data):
+    manufacturer = data.get('manufacturer')
+    script = data.get('script')
+    if not manufacturer or not script:
+        socketio.emit('output', 'Missing selection\n', to=request.sid)
+        return
+
+    path = SCRIPT_DIRS.get(manufacturer)
+    script_path = os.path.join(path, script)
+    if not os.path.isfile(script_path):
+        socketio.emit('output', 'Script not found\n', to=request.sid)
+        return
+
+    def run():
+        process = subprocess.Popen(
+            ['python3', script_path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True
+        )
+        for line in process.stdout:
+            socketio.emit('output', line, to=request.sid)
+        process.wait()
+        socketio.emit('finished', {'returncode': process.returncode}, to=request.sid)
+
+    socketio.start_background_task(run)
+
+
+if __name__ == '__main__':
+    socketio.run(app, host='0.0.0.0', port=5000)

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+Flask-SocketIO

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html>
+<head>
+    <title>Device Configurator</title>
+    <script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
+</head>
+<body>
+    <h1>Run Device Configuration</h1>
+    <label for="manufacturer">Manufacturer:</label>
+    <select id="manufacturer">
+        <option value="">Select...</option>
+        {% for m in scripts.keys() %}
+        <option value="{{ m }}">{{ m }}</option>
+        {% endfor %}
+    </select>
+
+    <label for="script">Device:</label>
+    <select id="script"></select>
+    <button id="run">Run</button>
+
+    <pre id="output"></pre>
+
+    <script>
+    const scripts = {{ scripts|tojson }};
+    const manufSelect = document.getElementById('manufacturer');
+    const scriptSelect = document.getElementById('script');
+
+    manufSelect.addEventListener('change', () => {
+        const val = manufSelect.value;
+        scriptSelect.innerHTML = '';
+        if (scripts[val]) {
+            scripts[val].forEach(s => {
+                const opt = document.createElement('option');
+                opt.value = s;
+                opt.textContent = s;
+                scriptSelect.appendChild(opt);
+            });
+        }
+    });
+
+    const socket = io();
+    document.getElementById('run').addEventListener('click', () => {
+        const m = manufSelect.value;
+        const s = scriptSelect.value;
+        document.getElementById('output').textContent = '';
+        socket.emit('run_script', {manufacturer: m, script: s});
+    });
+
+    socket.on('output', line => {
+        document.getElementById('output').textContent += line;
+    });
+
+    socket.on('finished', data => {
+        document.getElementById('output').textContent += '\nProcess exited with ' + data.returncode;
+    });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Flask webapp with SocketIO to run existing device scripts
- expose dropdowns for manufacturer and device script in an HTML template
- capture script output via SocketIO and show in browser
- note dependencies in requirements file

## Testing
- `git status --short`
- *No automated tests provided in repository*


------
https://chatgpt.com/codex/tasks/task_e_68552ead817483258f3a323ad6465249