### PR TITLE
Add background script execution

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from flask import Flask, render_template, request
 from flask_socketio import SocketIO
 import os
 import json
+import subprocess
 
 app = Flask(__name__)
 app.config['SECRET_KEY'] = 'secret!'
@@ -15,6 +16,26 @@ def get_scripts():
         return json.load(f)
 
 
+def run_command(cmd, sid):
+    """Run a command and stream each output line back to the client."""
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        for line in proc.stdout:
+            socketio.emit('output', line, to=sid)
+        returncode = proc.wait()
+    except Exception as exc:
+        socketio.emit('output', f"Error: {exc}\n", to=sid)
+        returncode = -1
+
+    socketio.emit('finished', {'returncode': returncode}, to=sid)
+
+
 @app.route('/')
 def index():
     scripts = get_scripts()
@@ -26,12 +47,14 @@ def run_script(data):
     manufacturer = data.get('manufacturer')
     device = data.get('device')
     script = data.get('script')
+    sid = request.sid
     if not manufacturer or not device or not script:
-        socketio.emit('output', 'Missing selection\n', to=request.sid)
+        socketio.emit('output', 'Missing selection\n', to=sid)
+        socketio.emit('finished', {'returncode': -1}, to=sid)
         return
 
-    socketio.emit('output', f"Running {script} for {manufacturer} {device}\n", to=request.sid)
-    socketio.emit('finished', {'returncode': 0}, to=request.sid)
+    socketio.emit('output', f"Running {script} for {manufacturer} {device}\n", to=sid)
+    socketio.start_background_task(run_command, script, sid)
 
 
 if __name__ == '__main__':

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,26 @@
-#Provisioning Pi
+# Provisioning Pi
+
+This Flask application exposes a small web UI to run provisioning scripts. The
+available scripts are defined in `devices.json` and grouped by manufacturer and
+model. The UI lets you choose a combination and run the corresponding script.
+
+## Running the app
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Then browse to `http://localhost:5000`.
+
+## How script execution works
+
+When **Run** is clicked the selected script name is sent to the server over a
+Socket.IO channel. The server starts the command in a background thread using
+`subprocess.Popen`. Each line of output from the command is emitted back to the
+browser via `socketio.emit('output', line)`. When the command finishes the final
+return code is sent using the `finished` event. The browser appends the output
+and exit status to the console area.
+
+The actual script value is executed directly by the operating system, so it can
+be any shell command or script path available on the host.


### PR DESCRIPTION
## Summary
- run selected scripts in a background thread
- stream each output line to the web UI
- report final return code when complete
- document how scripts are executed and streamed

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68553927f87483258e851055ed800f46