### PR TITLE
Add home and device configuration pages with navbar

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,8 +66,15 @@ def run_commands(script, params_list, sid):
 
 @app.route('/')
 def index():
+    """Render the home page."""
+    return render_template('index.html')
+
+
+@app.route('/device-config')
+def device_config():
+    """Display the device configuration page."""
     devices = get_devices()
-    return render_template('index.html', devices=devices)
+    return render_template('device_config.html', devices=devices)
 
 
 @socketio.on('run_script')

--- a/templates/device_config.html
+++ b/templates/device_config.html
@@ -1,0 +1,221 @@
+<!doctype html>
+<html>
+<head>
+    <title>Device Configurator</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <style>
+        body {
+            background-color: #f8f9fa;
+        }
+        .card {
+            border-radius: .5rem;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        #output {
+            height: 600px;
+            overflow-y: auto;
+            font-family: monospace;
+            background: #212529;
+            color: #f8f9fa;
+            border-radius: .5rem;
+        }
+    </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container">
+    <a class="navbar-brand" href="{{ url_for('index') }}">Provisioning Pi</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="{{ url_for('device_config') }}">Device Configuration</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container py-5">
+    <div class="card p-4">
+        <h1 class="mb-4">Run Device Configuration</h1>
+        <div class="row g-3 align-items-end">
+        <div class="col-md-2">
+            <label for="manufacturer" class="form-label">Manufacturer</label>
+            <select id="manufacturer" class="form-select">
+                <option value="">Select...</option>
+                {% for m in devices.keys() %}
+                <option value="{{ m }}">{{ m }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="col-md-2">
+            <label for="device" class="form-label">Device</label>
+            <select id="device" class="form-select"></select>
+        </div>
+        <div class="col-md-2">
+            <label for="site_type" class="form-label">Site Type</label>
+            <select id="site_type" class="form-select"></select>
+        </div>
+        <div class="col-md-2">
+            <label for="config_type" class="form-label">Configuration Type</label>
+            <select id="config_type" class="form-select"></select>
+        </div>
+        <div class="col-md-2">
+            <button id="run" class="btn btn-primary w-100">Run</button>
+        </div>
+    </div>
+
+    <div class="row g-3 mt-3">
+        <div class="col-12">
+            <h5>Device Config (CSV, one device per line)</h5>
+            <label id="csv_label" for="csv_input" class="form-label">Device Config (CSV, one device per line)</label>
+            <textarea id="csv_input" class="form-control" rows="4"></textarea>
+        </div>
+    </div>
+
+    <pre id="output" class="bg-dark text-white mt-4 p-3" style="height: 600px; overflow-y: auto;"></pre>
+    </div>
+</div>
+
+    <script>
+    const devices = {{ devices|tojson }};
+    const manufSelect = document.getElementById('manufacturer');
+    const deviceSelect = document.getElementById('device');
+    const siteTypeSelect = document.getElementById('site_type');
+    const configTypeSelect = document.getElementById('config_type');
+    const csvInput = document.getElementById('csv_input');
+    const outputEl = document.getElementById('output');
+    let selectedScript = '';
+
+    function resetSelect(sel) {
+        sel.innerHTML = '';
+        const opt = document.createElement('option');
+        opt.value = '';
+        opt.textContent = 'Select...';
+        sel.appendChild(opt);
+    }
+
+    resetSelect(deviceSelect);
+    resetSelect(siteTypeSelect);
+    resetSelect(configTypeSelect);
+
+    manufSelect.addEventListener('change', () => {
+        const m = manufSelect.value;
+        resetSelect(deviceSelect);
+        resetSelect(siteTypeSelect);
+        resetSelect(configTypeSelect);
+        selectedScript = '';
+        if (devices[m]) {
+            Object.keys(devices[m]).forEach(d => {
+                const opt = document.createElement('option');
+                opt.value = d;
+                opt.textContent = d;
+                deviceSelect.appendChild(opt);
+            });
+        }
+    });
+
+    deviceSelect.addEventListener('change', () => {
+        const m = manufSelect.value;
+        const d = deviceSelect.value;
+
+        resetSelect(siteTypeSelect);
+        resetSelect(configTypeSelect);
+        selectedScript = '';
+
+        const csvLabel = document.getElementById('csv_label');
+        const csvInput = document.getElementById('csv_input');
+
+        if (devices[m] && devices[m][d]) {
+            const deviceData = devices[m][d];
+
+            // ✅ Set CSV label and placeholder if format exists
+            if (deviceData.csv_format) {
+                csvLabel.textContent = `Device Config (CSV: ${deviceData.csv_format})`;
+                csvInput.placeholder = deviceData.csv_format;
+            } else {
+                csvLabel.textContent = "Device Config (CSV, one device per line)";
+                csvInput.placeholder = "name,ip,bridge,frequency";
+            }
+
+            // ✅ Populate site types, skipping "csv_format"
+            Object.keys(deviceData).forEach(st => {
+                if (st === "csv_format") return;  // skip non-site-type keys
+                const opt = document.createElement('option');
+                opt.value = st;
+                opt.textContent = st;
+                siteTypeSelect.appendChild(opt);
+            });
+        }
+    });
+
+
+    siteTypeSelect.addEventListener('change', () => {
+        const m = manufSelect.value;
+        const d = deviceSelect.value;
+        const st = siteTypeSelect.value;
+        resetSelect(configTypeSelect);
+        selectedScript = '';
+        if (devices[m] && devices[m][d] && devices[m][d][st]) {
+            Object.keys(devices[m][d][st]).forEach(ct => {
+                const opt = document.createElement('option');
+                opt.value = ct;
+                opt.textContent = ct;
+                configTypeSelect.appendChild(opt);
+            });
+        }
+    });
+
+    configTypeSelect.addEventListener('change', () => {
+        const m = manufSelect.value;
+        const d = deviceSelect.value;
+        const st = siteTypeSelect.value;
+        const ct = configTypeSelect.value;
+        selectedScript = '';
+        if (devices[m] && devices[m][d] && devices[m][d][st] && devices[m][d][st][ct]) {
+            selectedScript = devices[m][d][st][ct][0] || '';
+        }
+    });
+
+    const socket = io();
+    document.getElementById('run').addEventListener('click', () => {
+        const m = manufSelect.value;
+        const d = deviceSelect.value;
+        const st = siteTypeSelect.value;
+        const ct = configTypeSelect.value;
+        const csvLines = csvInput.value.split('\n')
+            .map(l => l.trim())
+            .filter(l => l)
+            .map(l => l.split(',')
+                .map(f => f.trim().replace(/\s+/g, '_'))
+                .join(','));
+        outputEl.textContent = '';
+        socket.emit('run_script', {
+            manufacturer: m,
+            device: d,
+            site_type: st,
+            config_type: ct,
+            script: selectedScript,
+            csv: csvLines
+        });
+    });
+
+    socket.on('output', line => {
+        outputEl.textContent += line;
+        outputEl.scrollTop = outputEl.scrollHeight;
+    });
+
+    socket.on('finished', data => {
+        outputEl.textContent += '\nProcess exited with ' + data.returncode;
+        outputEl.scrollTop = outputEl.scrollHeight;
+    });
+    </script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,203 +1,33 @@
 <!doctype html>
 <html>
 <head>
-    <title>Device Configurator</title>
+    <title>Provisioning Pi</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="https://cdn.socket.io/4.5.4/socket.io.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <style>
-        body {
-            background-color: #f8f9fa;
-        }
-        .card {
-            border-radius: .5rem;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-        }
-        #output {
-            height: 600px;
-            overflow-y: auto;
-            font-family: monospace;
-            background: #212529;
-            color: #f8f9fa;
-            border-radius: .5rem;
-        }
-    </style>
 </head>
 <body>
-<div class="container py-5">
-    <div class="card p-4">
-        <h1 class="mb-4">Run Device Configuration</h1>
-        <div class="row g-3 align-items-end">
-        <div class="col-md-2">
-            <label for="manufacturer" class="form-label">Manufacturer</label>
-            <select id="manufacturer" class="form-select">
-                <option value="">Select...</option>
-                {% for m in devices.keys() %}
-                <option value="{{ m }}">{{ m }}</option>
-                {% endfor %}
-            </select>
-        </div>
-        <div class="col-md-2">
-            <label for="device" class="form-label">Device</label>
-            <select id="device" class="form-select"></select>
-        </div>
-        <div class="col-md-2">
-            <label for="site_type" class="form-label">Site Type</label>
-            <select id="site_type" class="form-select"></select>
-        </div>
-        <div class="col-md-2">
-            <label for="config_type" class="form-label">Configuration Type</label>
-            <select id="config_type" class="form-select"></select>
-        </div>
-        <div class="col-md-2">
-            <button id="run" class="btn btn-primary w-100">Run</button>
-        </div>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container">
+    <a class="navbar-brand" href="{{ url_for('index') }}">Provisioning Pi</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a class="nav-link active" aria-current="page" href="{{ url_for('index') }}">Home</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="{{ url_for('device_config') }}">Device Configuration</a>
+        </li>
+      </ul>
     </div>
+  </div>
+</nav>
 
-    <div class="row g-3 mt-3">
-        <div class="col-12">
-            <h5>Device Config (CSV, one device per line)</h5>
-            <label id="csv_label" for="csv_input" class="form-label">Device Config (CSV, one device per line)</label>
-            <textarea id="csv_input" class="form-control" rows="4"></textarea>
-        </div>
-    </div>
-
-    <pre id="output" class="bg-dark text-white mt-4 p-3" style="height: 600px; overflow-y: auto;"></pre>
-    </div>
+<div class="container py-5 text-center">
+  <h1 class="mb-4">Provisioning Pi</h1>
+  <a href="{{ url_for('device_config') }}" class="btn btn-primary btn-lg">Go to Device Configuration</a>
 </div>
-
-    <script>
-    const devices = {{ devices|tojson }};
-    const manufSelect = document.getElementById('manufacturer');
-    const deviceSelect = document.getElementById('device');
-    const siteTypeSelect = document.getElementById('site_type');
-    const configTypeSelect = document.getElementById('config_type');
-    const csvInput = document.getElementById('csv_input');
-    const outputEl = document.getElementById('output');
-    let selectedScript = '';
-
-    function resetSelect(sel) {
-        sel.innerHTML = '';
-        const opt = document.createElement('option');
-        opt.value = '';
-        opt.textContent = 'Select...';
-        sel.appendChild(opt);
-    }
-
-    resetSelect(deviceSelect);
-    resetSelect(siteTypeSelect);
-    resetSelect(configTypeSelect);
-
-    manufSelect.addEventListener('change', () => {
-        const m = manufSelect.value;
-        resetSelect(deviceSelect);
-        resetSelect(siteTypeSelect);
-        resetSelect(configTypeSelect);
-        selectedScript = '';
-        if (devices[m]) {
-            Object.keys(devices[m]).forEach(d => {
-                const opt = document.createElement('option');
-                opt.value = d;
-                opt.textContent = d;
-                deviceSelect.appendChild(opt);
-            });
-        }
-    });
-
-    deviceSelect.addEventListener('change', () => {
-        const m = manufSelect.value;
-        const d = deviceSelect.value;
-
-        resetSelect(siteTypeSelect);
-        resetSelect(configTypeSelect);
-        selectedScript = '';
-
-        const csvLabel = document.getElementById('csv_label');
-        const csvInput = document.getElementById('csv_input');
-
-        if (devices[m] && devices[m][d]) {
-            const deviceData = devices[m][d];
-
-            // ✅ Set CSV label and placeholder if format exists
-            if (deviceData.csv_format) {
-                csvLabel.textContent = `Device Config (CSV: ${deviceData.csv_format})`;
-                csvInput.placeholder = deviceData.csv_format;
-            } else {
-                csvLabel.textContent = "Device Config (CSV, one device per line)";
-                csvInput.placeholder = "name,ip,bridge,frequency";
-            }
-
-            // ✅ Populate site types, skipping "csv_format"
-            Object.keys(deviceData).forEach(st => {
-                if (st === "csv_format") return;  // skip non-site-type keys
-                const opt = document.createElement('option');
-                opt.value = st;
-                opt.textContent = st;
-                siteTypeSelect.appendChild(opt);
-            });
-        }
-    });
-
-
-    siteTypeSelect.addEventListener('change', () => {
-        const m = manufSelect.value;
-        const d = deviceSelect.value;
-        const st = siteTypeSelect.value;
-        resetSelect(configTypeSelect);
-        selectedScript = '';
-        if (devices[m] && devices[m][d] && devices[m][d][st]) {
-            Object.keys(devices[m][d][st]).forEach(ct => {
-                const opt = document.createElement('option');
-                opt.value = ct;
-                opt.textContent = ct;
-                configTypeSelect.appendChild(opt);
-            });
-        }
-    });
-
-    configTypeSelect.addEventListener('change', () => {
-        const m = manufSelect.value;
-        const d = deviceSelect.value;
-        const st = siteTypeSelect.value;
-        const ct = configTypeSelect.value;
-        selectedScript = '';
-        if (devices[m] && devices[m][d] && devices[m][d][st] && devices[m][d][st][ct]) {
-            selectedScript = devices[m][d][st][ct][0] || '';
-        }
-    });
-
-    const socket = io();
-    document.getElementById('run').addEventListener('click', () => {
-        const m = manufSelect.value;
-        const d = deviceSelect.value;
-        const st = siteTypeSelect.value;
-        const ct = configTypeSelect.value;
-        const csvLines = csvInput.value.split('\n')
-            .map(l => l.trim())
-            .filter(l => l)
-            .map(l => l.split(',')
-                .map(f => f.trim().replace(/\s+/g, '_'))
-                .join(','));
-        outputEl.textContent = '';
-        socket.emit('run_script', {
-            manufacturer: m,
-            device: d,
-            site_type: st,
-            config_type: ct,
-            script: selectedScript,
-            csv: csvLines
-        });
-    });
-
-    socket.on('output', line => {
-        outputEl.textContent += line;
-        outputEl.scrollTop = outputEl.scrollHeight;
-    });
-
-    socket.on('finished', data => {
-        outputEl.textContent += '\nProcess exited with ' + data.returncode;
-        outputEl.scrollTop = outputEl.scrollHeight;
-    });
-    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- create new `device_config.html` template from old index
- simplify `index.html` to act as a landing page
- add Bootstrap navbar to both pages
- add `/device-config` route and use `index` for landing page

## Testing
- `python -m py_compile app.py cambium/nbn/3000l.py cambium/rcp/3000l.py`

------
https://chatgpt.com/codex/tasks/task_e_68554e03ae4c832587dbb98d3406c9dc