### PR TITLE
Add WYSIWYG editor to label printer

### DIFF
--- a/templates/label_printer.html
+++ b/templates/label_printer.html
@@ -45,8 +45,17 @@
   <div class="card p-4">
     <h1 class="mb-4">Label Printer</h1>
     <div class="mb-3">
-      <label for="label_text" class="form-label">Label Text</label>
-      <textarea id="label_text" class="form-control" rows="2" placeholder="Enter label text"></textarea>
+      <label class="form-label">Label Text</label>
+      <div class="btn-toolbar mb-2">
+        <button type="button" class="btn btn-outline-secondary me-2" id="bold_btn"><strong>B</strong></button>
+        <select id="font_size" class="form-select w-auto">
+          <option value="30">30px</option>
+          <option value="40">40px</option>
+          <option value="50" selected>50px</option>
+          <option value="60">60px</option>
+        </select>
+      </div>
+      <div id="label_text" class="form-control" contenteditable="true" style="min-height:70px;"></div>
     </div>
     <div class="mb-3">
       <label class="form-label">Preview</label>
@@ -58,12 +67,33 @@
 <script>
   const preview = document.getElementById('preview');
   const labelInput = document.getElementById('label_text');
-  labelInput.addEventListener('input', () => {
-    preview.textContent = labelInput.value;
+  const fontSize = document.getElementById('font_size');
+  const boldBtn = document.getElementById('bold_btn');
+
+  function updatePreview() {
+    preview.innerHTML = labelInput.innerHTML;
+  }
+
+  labelInput.addEventListener('input', updatePreview);
+
+  boldBtn.addEventListener('click', () => {
+    document.execCommand('bold');
+    updatePreview();
   });
+
+  fontSize.addEventListener('change', () => {
+    const size = fontSize.value + 'px';
+    labelInput.style.fontSize = size;
+    preview.style.fontSize = size;
+  });
+
   const socket = io();
   document.getElementById('print_btn').addEventListener('click', () => {
-    socket.emit('print_label', { text: labelInput.value });
+    socket.emit('print_label', { html: labelInput.innerHTML });
+  });
+
+  window.addEventListener('DOMContentLoaded', () => {
+    fontSize.dispatchEvent(new Event('change'));
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- implement simple editor with bold and font-size controls
- update label printer preview to reflect editor formatting

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685556c53f04832589adab6f6324376e