### PR TITLE
Implement label printing endpoint

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,3 +24,10 @@ and exit status to the console area.
 
 The actual script value is executed directly by the operating system, so it can
 be any shell command or script path available on the host.
+
+## Label printing
+
+When the **Print** button is used on the label printer page, the browser sends a
+`print_label` Socket.IO event containing the HTML for the label. The server
+saves the received HTML to `last_label.html` and replies with an `output` message
+showing the path. A final `finished` event indicates completion.


### PR DESCRIPTION
## Summary
- add a Socket.IO `print_label` handler to save HTML for label printing
- document label printing API in readme

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68555a2a46148325bf207912a291d4c9