### PR TITLE
Filter config rows and store UNIX timestamps

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,7 +22,7 @@ def get_devices():
 def log_configuration(manufacturer, device, site_type, config_type, csv_line):
     """Append a configuration record to LOG_FILE."""
     record = {
-        "timestamp": datetime.utcnow().isoformat(),
+        "timestamp": int(datetime.utcnow().timestamp()),
         "manufacturer": manufacturer,
         "device": device,
         "site_type": site_type,
@@ -137,7 +137,12 @@ def recent_configs():
 
 @app.route('/all-configs')
 def all_configs():
-    """Return all configuration records as JSON."""
+    """Return configuration records as JSON, optionally filtered."""
+    m = request.args.get('manufacturer')
+    d = request.args.get('device')
+    st = request.args.get('site_type')
+    ct = request.args.get('config_type')
+
     if not os.path.exists(LOG_FILE):
         return {'configs': []}
     try:
@@ -145,6 +150,16 @@ def all_configs():
             data = json.load(f)
     except Exception:
         data = []
+
+    if all([m, d, st, ct]):
+        data = [
+            r for r in data
+            if r.get('manufacturer') == m
+            and r.get('device') == d
+            and r.get('site_type') == st
+            and r.get('config_type') == ct
+        ]
+
     data.sort(key=lambda r: r.get('timestamp'), reverse=True)
     return {'configs': data}
 

--- a/templates/device_config.html
+++ b/templates/device_config.html
@@ -125,6 +125,7 @@
                 deviceSelect.appendChild(opt);
             });
         }
+        loadAllConfigs();
     });
 
     deviceSelect.addEventListener('change', () => {
@@ -159,6 +160,7 @@
                 siteTypeSelect.appendChild(opt);
             });
         }
+        loadAllConfigs();
     });
 
 
@@ -176,7 +178,21 @@
                 configTypeSelect.appendChild(opt);
             });
         }
+        loadAllConfigs();
     });
+
+    function formatTs(ts) {
+        if (ts === undefined || ts === null) return '';
+        if (typeof ts === 'string') {
+            const d = new Date(ts);
+            if (!isNaN(d)) {
+                return d.toLocaleDateString('en-GB') + ' ' + d.toLocaleTimeString('en-GB', {hour:'2-digit', minute:'2-digit', hour12:false});
+            }
+            ts = parseInt(ts, 10);
+        }
+        const d = new Date(Number(ts) * 1000);
+        return d.toLocaleDateString('en-GB') + ' ' + d.toLocaleTimeString('en-GB', {hour:'2-digit', minute:'2-digit', hour12:false});
+    }
 
     function loadRecent() {
         const m = manufSelect.value;
@@ -195,7 +211,7 @@
                 (data.configs || []).forEach(item => {
                     const li = document.createElement('li');
                     li.className = 'list-group-item';
-                    li.textContent = `${item.timestamp}: ${item.csv}`;
+                    li.textContent = `${formatTs(item.timestamp)}: ${item.csv}`;
                     list.appendChild(li);
                 });
             });
@@ -211,6 +227,7 @@
             selectedScript = devices[m][d][st][ct][0] || '';
         }
         loadRecent();
+        loadAllConfigs();
     });
 
     const socket = io();
@@ -250,7 +267,18 @@
 
     let configsTable;
     function loadAllConfigs() {
-        fetch('/all-configs')
+        const m = manufSelect.value;
+        const d = deviceSelect.value;
+        const st = siteTypeSelect.value;
+        const ct = configTypeSelect.value;
+        if (!m || !d || !st || !ct) {
+            if (configsTable) {
+                configsTable.clear().draw();
+            }
+            return;
+        }
+        const params = `manufacturer=${encodeURIComponent(m)}&device=${encodeURIComponent(d)}&site_type=${encodeURIComponent(st)}&config_type=${encodeURIComponent(ct)}`;
+        fetch(`/all-configs?${params}`)
             .then(r => r.json())
             .then(data => {
                 if (configsTable) {
@@ -259,7 +287,7 @@
                     configsTable = $('#all_configs').DataTable({
                         data: data.configs || [],
                         columns: [
-                            { data: 'timestamp' },
+                            { data: 'timestamp', render: data => formatTs(data) },
                             { data: 'manufacturer' },
                             { data: 'device' },
                             { data: 'site_type' },


### PR DESCRIPTION
## Summary
- persist timestamps in `configured.json` as Unix epoch values
- filter `/all-configs` endpoint by selected hardware
- format timestamps in the UI as `dd/mm/yyyy hh:mm`
- filter DataTable rows based on the current dropdown selection

## Testing
- `python -m py_compile app.py cambium/reset.py victron/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6856078858848325ac9dc57da46c1491