### PR TITLE
Improve output handling UI

### DIFF
--- a/templates/device_config.html
+++ b/templates/device_config.html
@@ -72,7 +72,13 @@
         </div>
     </div>
 
-    <pre id="output" class="bg-dark text-white mt-4 p-3" style="height: 600px; overflow-y: auto;"></pre>
+    <div class="mt-3">
+        <button class="btn btn-secondary mb-2" type="button" data-bs-toggle="collapse" data-bs-target="#outputCollapse" aria-expanded="false" aria-controls="outputCollapse">Toggle Output</button>
+        <div id="status_line" class="fw-bold mb-2"></div>
+        <div class="collapse" id="outputCollapse">
+            <pre id="output" class="bg-dark text-white p-3" style="height: 600px; overflow-y: auto;"></pre>
+        </div>
+    </div>
     <table id="all_configs" class="table table-striped table-bordered mt-4" style="width:100%">
         <thead></thead>
         <tbody></tbody>
@@ -88,6 +94,7 @@
     const configTypeSelect = document.getElementById('config_type');
     const csvInput = document.getElementById('csv_input');
     const outputEl = document.getElementById('output');
+    const statusEl = document.getElementById('status_line');
     let selectedScript = '';
 
     function resetSelect(sel) {
@@ -234,6 +241,7 @@
                 .map(f => f.trim().replace(/\s+/g, '_'))
                 .join(','));
         outputEl.textContent = '';
+        statusEl.textContent = '';
         socket.emit('run_script', {
             manufacturer: m,
             device: d,
@@ -247,11 +255,17 @@
     socket.on('output', line => {
         outputEl.textContent += line;
         outputEl.scrollTop = outputEl.scrollHeight;
+        const trimmed = line.trim();
+        if (trimmed) {
+            statusEl.textContent = trimmed;
+        }
     });
 
     socket.on('finished', data => {
-        outputEl.textContent += '\nProcess exited with ' + data.returncode;
+        const msg = '\nProcess exited with ' + data.returncode;
+        outputEl.textContent += msg;
         outputEl.scrollTop = outputEl.scrollHeight;
+        statusEl.textContent = msg.trim();
         loadRecent();
         loadAllConfigs();
     });
@@ -287,17 +301,12 @@
 
                 const headerRow = document.createElement('tr');
                 const columns = [
-                    { data: 'timestamp', title: 'Timestamp', render: d => formatTs(d) },
-                    { data: 'config_type', title: 'Config Type' }
+                    { data: 'timestamp', title: 'Timestamp', render: d => formatTs(d) }
                 ];
 
                 const thTs = document.createElement('th');
                 thTs.textContent = 'Timestamp';
                 headerRow.appendChild(thTs);
-
-                const thCt = document.createElement('th');
-                thCt.textContent = 'Config Type';
-                headerRow.appendChild(thCt);
 
                 csvHeaders.forEach((h, idx) => {
                     const display = h.replace(/([a-z])([A-Z])/g, '$1 $2');

--- a/templates/device_reset.html
+++ b/templates/device_reset.html
@@ -29,26 +29,40 @@
 <div class="container py-5">
     <div class="card p-4">
         <h1 class="mb-4">Device Reset Tool</h1>
-    <pre id="output" class="bg-dark text-white mt-4 p-3" style="height: 600px; overflow-y: auto;"></pre>
+    <div class="mt-3">
+        <button class="btn btn-secondary mb-2" type="button" data-bs-toggle="collapse" data-bs-target="#outputCollapse" aria-expanded="false" aria-controls="outputCollapse">Toggle Output</button>
+        <div id="status_line" class="fw-bold mb-2"></div>
+        <div class="collapse" id="outputCollapse">
+            <pre id="output" class="bg-dark text-white p-3" style="height: 600px; overflow-y: auto;"></pre>
+        </div>
+    </div>
     </div>
 </div>
 
     <script>
     const socket = io();
     const outputEl = document.getElementById('output');
+    const statusEl = document.getElementById('status_line');
 
     socket.on('output', line => {
         outputEl.textContent += line;
         outputEl.scrollTop = outputEl.scrollHeight;
+        const trimmed = line.trim();
+        if (trimmed) {
+            statusEl.textContent = trimmed;
+        }
     });
 
     socket.on('finished', data => {
-        outputEl.textContent += '\nProcess exited with ' + data.returncode;
+        const msg = '\nProcess exited with ' + data.returncode;
+        outputEl.textContent += msg;
         outputEl.scrollTop = outputEl.scrollHeight;
+        statusEl.textContent = msg.trim();
     });
 
     window.addEventListener('load', () => {
         outputEl.textContent = '';
+        statusEl.textContent = '';
         socket.emit('run_reset');
     });
     </script>

--- a/templates/telemetry_device.html
+++ b/templates/telemetry_device.html
@@ -29,26 +29,40 @@
 <div class="container py-5">
     <div class="card p-4">
         <h1 class="mb-4">Telemetry TinyS3 Configuration</h1>
-    <pre id="output" class="bg-dark text-white mt-4 p-3" style="height: 600px; overflow-y: auto;"></pre>
+    <div class="mt-3">
+        <button class="btn btn-secondary mb-2" type="button" data-bs-toggle="collapse" data-bs-target="#outputCollapse" aria-expanded="false" aria-controls="outputCollapse">Toggle Output</button>
+        <div id="status_line" class="fw-bold mb-2"></div>
+        <div class="collapse" id="outputCollapse">
+            <pre id="output" class="bg-dark text-white p-3" style="height: 600px; overflow-y: auto;"></pre>
+        </div>
+    </div>
     </div>
 </div>
 
     <script>
     const socket = io();
     const outputEl = document.getElementById('output');
+    const statusEl = document.getElementById('status_line');
 
     socket.on('output', line => {
         outputEl.textContent += line;
         outputEl.scrollTop = outputEl.scrollHeight;
+        const trimmed = line.trim();
+        if (trimmed) {
+            statusEl.textContent = trimmed;
+        }
     });
 
     socket.on('finished', data => {
-        outputEl.textContent += '\nProcess exited with ' + data.returncode;
+        const msg = '\nProcess exited with ' + data.returncode;
+        outputEl.textContent += msg;
         outputEl.scrollTop = outputEl.scrollHeight;
+        statusEl.textContent = msg.trim();
     });
 
     window.addEventListener('load', () => {
         outputEl.textContent = '';
+        statusEl.textContent = '';
         socket.emit('configure_tinys3');
     });
     </script>


### PR DESCRIPTION
## Summary
- hide script output in a collapsible section on the Device Configuration, Device Reset and Telemetry pages
- show the most recent output line above the collapsed section
- remove the Config Type column from the Device Configuration history table

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68560d23bf788325a03cfcbb4bae810a