### PR TITLE
Add stop button to terminate running scripts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,10 @@ return code is sent using the `finished` event. The browser appends the output
 and exit status to the console area.
 
 The actual script value is executed directly by the operating system, so it can
-be any shell command or script path available on the host.
+be any shell command or script path available on the host. While a script is
+running the **Run** button turns into a red **Stop** button. Clicking it sends a
+`stop_script` event to the server which terminates the running process and
+emits the final `finished` message.
 
 ## Label printing
 

--- a/templates/device_config.html
+++ b/templates/device_config.html
@@ -229,7 +229,15 @@
     });
 
     const socket = io();
-    document.getElementById('run').addEventListener('click', () => {
+    const runBtn = document.getElementById('run');
+    let running = false;
+
+    runBtn.addEventListener('click', () => {
+        if (running) {
+            socket.emit('stop_script');
+            return;
+        }
+
         const m = manufSelect.value;
         const d = deviceSelect.value;
         const st = siteTypeSelect.value;
@@ -250,6 +258,10 @@
             script: selectedScript,
             csv: csvLines
         });
+        runBtn.textContent = 'Stop';
+        runBtn.classList.remove('btn-primary');
+        runBtn.classList.add('btn-danger');
+        running = true;
     });
 
     socket.on('output', line => {
@@ -266,6 +278,10 @@
         outputEl.textContent += msg;
         outputEl.scrollTop = outputEl.scrollHeight;
         statusEl.textContent = msg.trim();
+        runBtn.textContent = 'Run';
+        runBtn.classList.remove('btn-danger');
+        runBtn.classList.add('btn-primary');
+        running = false;
         loadRecent();
         loadAllConfigs();
     });


### PR DESCRIPTION
## Summary
- allow Flask server to track running processes
- add Socket.IO endpoint to stop scripts
- register processes for stop control
- update device configuration page with Stop button logic
- document stopping scripts in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6858b12f0be88325a334ea375750aab9