### PR TITLE
Improve logging integration

### DIFF
--- a/cambium/rcp/f300-25-ap-remote.py
+++ b/cambium/rcp/f300-25-ap-remote.py
@@ -383,8 +383,10 @@ if '1' in cnmenabled:
 else:
       print (Fore.RED + "CNMaestro is disabled!")
       quit()
-functions.insert_data("serial_number", serial_number)
-functions.insert_data("mac_address", mac_address)
+functions.append_to_last_record({
+    "serial_number": serial_number,
+    "mac_address": mac_address,
+})
 
 #Updating google spreadsheet RP3 Data
 #gsheet.add_to_sheet(serial_number, mac_address, device_name, ip_address, fwv, hardware, smc_ping)

--- a/readme.md
+++ b/readme.md
@@ -50,4 +50,7 @@ functions.insert_data("serial_number", "abcd1234")
 
 # Or multiple fields at once
 functions.insert_data(serial="S1", mac="00:11:22:33:44:55")
+
+# Alternatively update the most recent entry
+functions.append_to_last_record({"serial_number": "abcd1234", "mac": "00:11:22:33:44:55"})
 ```


### PR DESCRIPTION
## Summary
- add a helper to merge data into the most recent log entry
- use the new helper in the F300 AP Remote script
- document how to use `append_to_last_record`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f342e3148325a7e300d663572391