### PR TITLE
Add label print option to telemetry page

### DIFF
--- a/app.py
+++ b/app.py
@@ -281,12 +281,18 @@ def run_reset():
     socketio.start_background_task(run_command, 'cambium/reset.py', sid)
 
 @socketio.on('configure_tinys3')
-def configure_tinys3():
-    """Run the Cambium reset script without any parameters."""
+def configure_tinys3(data=None):
+    """Run the TinyS3 configuration script with optional label printing."""
     sid = request.sid
-    socketio.emit('output', 'Running victron/tinys3_configuration.py\n', to=sid)
+    print_label = False
+    if isinstance(data, dict):
+        print_label = bool(data.get('print_label'))
+    script = 'victron/tinys3_configuration.py'
+    if print_label:
+        script += ' --print-label'
+    socketio.emit('output', f'Running {script}\n', to=sid)
     RUNNING[sid] = {'stop_event': Event(), 'process': None}
-    socketio.start_background_task(run_command, 'victron/tinys3_configuration.py', sid)
+    socketio.start_background_task(run_command, script, sid)
 
 
 @socketio.on('print_label')

--- a/templates/telemetry_device.html
+++ b/templates/telemetry_device.html
@@ -29,6 +29,17 @@
 <div class="container py-5">
     <div class="card p-4">
         <h1 class="mb-4">Telemetry TinyS3 Configuration</h1>
+    <div class="mb-3">
+        <div class="form-check">
+            <input class="form-check-input" type="checkbox" value="" id="print_label">
+            <label class="form-check-label" for="print_label">
+                Print label after configuration
+            </label>
+        </div>
+    </div>
+    <div class="mb-3">
+        <button id="configure_btn" class="btn btn-primary">Configure</button>
+    </div>
     <div class="mt-3">
         <button class="btn btn-secondary mb-2" type="button" data-bs-toggle="collapse" data-bs-target="#outputCollapse" aria-expanded="false" aria-controls="outputCollapse">Toggle Output</button>
         <div id="status_line" class="fw-bold mb-2"></div>
@@ -43,6 +54,9 @@
     const socket = io();
     const outputEl = document.getElementById('output');
     const statusEl = document.getElementById('status_line');
+    const printBox = document.getElementById('print_label');
+    const configureBtn = document.getElementById('configure_btn');
+    let running = false;
 
     socket.on('output', line => {
         outputEl.textContent += line;
@@ -58,12 +72,29 @@
         outputEl.textContent += msg;
         outputEl.scrollTop = outputEl.scrollHeight;
         statusEl.textContent = msg.trim();
+        configureBtn.textContent = 'Configure';
+        configureBtn.classList.remove('btn-danger');
+        configureBtn.classList.add('btn-primary');
+        running = false;
+    });
+
+    configureBtn.addEventListener('click', () => {
+        if (running) {
+            socket.emit('stop_script');
+            return;
+        }
+        outputEl.textContent = '';
+        statusEl.textContent = '';
+        socket.emit('configure_tinys3', { print_label: printBox.checked });
+        configureBtn.textContent = 'Stop';
+        configureBtn.classList.remove('btn-primary');
+        configureBtn.classList.add('btn-danger');
+        running = true;
     });
 
     window.addEventListener('load', () => {
         outputEl.textContent = '';
         statusEl.textContent = '';
-        socket.emit('configure_tinys3');
     });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add a print label checkbox and manual Configure button
- send checkbox state to the backend
- update backend `configure_tinys3` handler to accept the option

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68592e64564c8325bf48fc424ac909eb