### PR TITLE
Add QR code label printing

### DIFF
--- a/print_label.py
+++ b/print_label.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Print a label on the Brother printer."""
+import argparse
+import os
+import logging
+from io import BytesIO
+from PIL import Image, ImageDraw, ImageFont
+from brother_ql import BrotherQLRaster, create_label
+from brother_ql.backends.helpers import send
+import qrcode
+
+logging.basicConfig(level=logging.ERROR)
+
+DEFAULT_MODEL = os.environ.get('BROTHER_QL_MODEL', 'QL-700')
+DEFAULT_ADDRESS = os.environ.get('BROTHER_QL_PRINTER', 'usb://04f9:2042')
+FONT_PATH = os.path.join(os.path.dirname(__file__), 'brother', 'Roboto-Regular.ttf')
+LABEL_TYPE = '17x54'
+
+
+def build_image(text: str, qr: bool) -> Image.Image:
+    """Generate label image with optional QR code."""
+    img = Image.new('L', (566, 165), color=255)
+    draw = ImageDraw.Draw(img)
+    font = ImageFont.truetype(FONT_PATH, 40)
+    draw.text((5, 60), text, font=font, fill=0)
+
+    if qr:
+        qr_img = qrcode.make(text).resize((120, 120))
+        img.paste(qr_img, (430, 20))
+    return img
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Print a text label")
+    parser.add_argument('--text', required=True, help='Text to print')
+    parser.add_argument('--qr', action='store_true', help='Print text as QR code')
+    args = parser.parse_args()
+
+    printer = BrotherQLRaster(DEFAULT_MODEL)
+    img = build_image(args.text, args.qr)
+    img_bytes = BytesIO()
+    img.save(img_bytes, format='PNG')
+    img_bytes.seek(0)
+
+    create_label(printer, img_bytes, LABEL_TYPE, cut=True)
+    send(printer.data, DEFAULT_ADDRESS)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 Flask
 Flask-SocketIO
+Pillow
+brother_ql
+qrcode

--- a/templates/label_printer.html
+++ b/templates/label_printer.html
@@ -48,6 +48,10 @@
       </div>
       <div id="label_text" class="form-control" contenteditable="true" style="min-height:70px;"></div>
     </div>
+    <div class="form-check mb-3">
+      <input class="form-check-input" type="checkbox" id="qr_check">
+      <label class="form-check-label" for="qr_check">Print text as QR code</label>
+    </div>
     <div class="mb-3">
       <label class="form-label">Preview</label>
       <div id="preview"></div>
@@ -60,6 +64,7 @@
   const labelInput = document.getElementById('label_text');
   const fontSize = document.getElementById('font_size');
   const boldBtn = document.getElementById('bold_btn');
+  const qrCheck = document.getElementById('qr_check');
 
   function updatePreview() {
     preview.innerHTML = labelInput.innerHTML;
@@ -80,7 +85,7 @@
 
   const socket = io();
   document.getElementById('print_btn').addEventListener('click', () => {
-    socket.emit('print_label', { html: labelInput.innerHTML });
+    socket.emit('print_label', { text: labelInput.innerText, qr: qrCheck.checked });
   });
 
   window.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- implement `print_label.py` for Brother QL printers with optional QR code
- update label printer page with QR code checkbox and new socket payload
- connect `print_label` socket event to run new script
- include printing dependencies in `requirements.txt`

## Testing
- `python3 -m py_compile app.py print_label.py`

------
https://chatgpt.com/codex/tasks/task_e_685b94320fec8325a55c668f4adca7fe