### PR TITLE
Move print_label into brother

### DIFF
--- a/app.py
+++ b/app.py
@@ -308,7 +308,7 @@ def print_label(data):
         socketio.emit('finished', {'returncode': -1}, to=sid)
         return
 
-    script = f"print_label.py --text {shlex.quote(text)}"
+    script = f"brother/print_label.py --text {shlex.quote(text)}"
     if qr:
         script += " --qr"
 

--- a/brother/print_label.py
+++ b/brother/print_label.py
@@ -13,7 +13,8 @@ logging.basicConfig(level=logging.ERROR)
 
 DEFAULT_MODEL = os.environ.get('BROTHER_QL_MODEL', 'QL-700')
 DEFAULT_ADDRESS = os.environ.get('BROTHER_QL_PRINTER', 'usb://04f9:2042')
-FONT_PATH = os.path.join(os.path.dirname(__file__), 'brother', 'Roboto-Regular.ttf')
+# Font file lives in the same directory as this script after moving
+FONT_PATH = os.path.join(os.path.dirname(__file__), 'Roboto-Regular.ttf')
 LABEL_TYPE = '17x54'
 
 


### PR DESCRIPTION
## Summary
- move `print_label.py` into the `brother` directory
- update `app.py` to call the new script path
- adjust font path in `brother/print_label.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b960daf6c8325842e35f890bb9279