### PR TITLE
Add barcode preview and switch to Code128

### DIFF
--- a/templates/label_printer.html
+++ b/templates/label_printer.html
@@ -10,17 +10,17 @@
         body { background-color: #f8f9fa; }
         .card { border-radius: .5rem; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
         #preview {
-            width: 340px;
-            height: 70px;
+            width: 566px;
+            height: 165px;
             border: 1px dashed #6c757d;
-            font-family: 'Roboto', sans-serif;
-            font-size: 55px;
             display: flex;
             align-items: center;
-            padding-left: 20px;
-            overflow: hidden;
-            white-space: nowrap;
+            justify-content: center;
             background: #fff;
+        }
+        #preview img {
+            max-width: 100%;
+            max-height: 100%;
         }
     </style>
 </head>
@@ -54,7 +54,7 @@
         <option value="">None</option>
         <option value="qr">QR Code</option>
         <option value="data_matrix">Data Matrix</option>
-        <option value="upc">UPC</option>
+        <option value="code128">Code 128</option>
       </select>
     </div>
     <div class="mb-3">
@@ -78,11 +78,25 @@
   const boldBtn = document.getElementById('bold_btn');
   const barcodeType = document.getElementById('barcode_type');
 
-  function updatePreview() {
-    preview.innerHTML = labelInput.innerHTML;
+  async function updatePreview() {
+    const resp = await fetch('/label_preview', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        text: labelInput.innerText,
+        barcode: barcodeType.value || null
+      })
+    });
+    if (resp.ok) {
+      const data = await resp.json();
+      preview.innerHTML = `<img src="data:image/png;base64,${data.image}" />`;
+    } else {
+      preview.textContent = labelInput.innerText;
+    }
   }
 
   labelInput.addEventListener('input', updatePreview);
+  barcodeType.addEventListener('change', updatePreview);
 
   boldBtn.addEventListener('click', () => {
     document.execCommand('bold');
@@ -92,7 +106,6 @@
   fontSize.addEventListener('change', () => {
     const size = fontSize.value + 'px';
     labelInput.style.fontSize = size;
-    preview.style.fontSize = size;
   });
 
   const socket = io();
@@ -142,6 +155,7 @@
     fontSize.dispatchEvent(new Event('change'));
     outputEl.textContent = '';
     statusEl.textContent = '';
+    updatePreview();
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- switch label barcode type from UPC to Code 128
- scale barcodes to label height
- provide `/label_preview` endpoint returning preview image
- render preview image with barcode on the label printer page

## Testing
- `python3 -m py_compile brother/print_label.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_685bad1718cc832586701e4ca42f8742