### PR TITLE
Add update feature to navbar

### DIFF
--- a/app.py
+++ b/app.py
@@ -354,5 +354,16 @@ def stop_script():
             pass
 
 
+@app.route('/update', methods=['POST'])
+def update():
+    """Pull latest code and restart the service."""
+    try:
+        subprocess.check_call(['git', 'pull', 'origin', 'main'])
+        subprocess.check_call(['sudo', 'systemctl', 'restart', 'provisioning.service'])
+        return {'status': 'ok'}
+    except subprocess.CalledProcessError as exc:
+        return {'status': 'error', 'returncode': exc.returncode}, 500
+
+
 if __name__ == '__main__':
     socketio.run(app, host='0.0.0.0', port=5000, allow_unsafe_werkzeug=True)

--- a/templates/header.html
+++ b/templates/header.html
@@ -24,6 +24,55 @@
           <a class="nav-link {% if active_page == 'label_printer' %}active{% endif %}" {% if active_page == 'label_printer' %}aria-current="page"{% endif %} href="{{ url_for('label_printer') }}">Label Printer</a>
         </li>
       </ul>
+      <ul class="navbar-nav ms-auto">
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            Settings
+          </a>
+          <ul class="dropdown-menu dropdown-menu-end">
+            <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#updateModal">Update</a></li>
+          </ul>
+        </li>
+      </ul>
+      </div>
+    </div>
+  </nav>
+
+<!-- Update Modal -->
+<div class="modal fade" id="updateModal" tabindex="-1" aria-labelledby="updateModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="updateModalLabel">Confirm Update</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        Are you sure you want to update?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">No</button>
+        <button type="button" class="btn btn-primary" id="confirmUpdate">Yes</button>
+      </div>
     </div>
   </div>
-</nav>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  var btn = document.getElementById('confirmUpdate');
+  if (btn) {
+    btn.addEventListener('click', function () {
+      fetch('/update', {method: 'POST'})
+        .then(function (res) {
+          if (res.ok) {
+            window.location.reload();
+          } else {
+            alert('Update failed');
+          }
+        })
+        .catch(function () { alert('Update failed'); })
+        .finally(function () { var modal = bootstrap.Modal.getInstance(document.getElementById('updateModal')); if (modal) modal.hide(); });
+    });
+  }
+});
+</script>


### PR DESCRIPTION
## Summary
- add a settings dropdown with an Update action in the navbar
- include a confirmation modal in `header.html`
- handle `/update` POST route to pull latest code and restart the provisioning service

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e5dce68708325b1e11ca0b1181300